### PR TITLE
integrity: add itegrity controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ samples at `./api.http`
 
 health check at GET `http://localhost:6789/health`
 
-source code integrity hashes at `GET http://localhost:6789/integrity`
+source code integrity hashes at GET `http://localhost:6789/integrity`
 
 integrity response:
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,24 @@ samples at `./api.http`
 
 health check at GET `http://localhost:6789/health`
 
+source code integrity hashes at `GET http://localhost:6789/integrity`
+
+integrity response:
+
+```json
+{
+  "integrity": "93c53eedd4fd32d832a4d4086f42ba8397d2d1690242183c128785a6e8969c7c",
+  "btcQuoteController": "1d5b779a64b0ff237624cef9c2a897b21c6496e4eb61a48674d674020f7dbe43",
+  "btcSwapController": "c16f9a67df5f4060cddb9c1179f29a228052f11ad0cd839ccbe9fd64bbb6d26a",
+  "btcQuoteService": "05adb103051b7025fe95fb0b152680e02c2aa305374bd5711d7984d5d08a803c",
+  "btcSwapService": "a3b021dba3f97b8dcb4c81ddede140574c61a1407c9b77aacd0a2d3f6a4c9cbf",
+  "xmrQuoteController": "3d1b335f974985871cf77aa1ab90863b051f960e3ead20c08f7e247c43d68b39",
+  "xmrSwapController": "95296e96e25331c88bbaee1bf5c08e30bd9adbaf7bbd6ee2bb107d3e87d3a18f",
+  "xmrQuoteService": "a2465a8fe8e61ba97e627074d6742c52fa5656d3fa5a31dbe2d9d052758d3a33",
+  "xmrSwapService": "30b07e5568355079595f44fde25bc9696d9dd8977bf2b2d105ad54773365e057"
+}
+```
+
 1. generate a quote at GET `http://localhost:6789/quote/xmr`
 
 ### quote request

--- a/api.http
+++ b/api.http
@@ -211,3 +211,6 @@ Content-Type: application/json
     "refundAddress": "54Czx3ETpFZJPeYJC9RPvD9MzTrRjtdM4AYkryvQVD9259CUZ3shG99S53LzWFr5E1jJgd9fqZkzZbVz28N4oCzJBMLjDpj",
     "swapMultisigInfos": ["MultisigV1U4127UrxYQhWE7MVtZwxzbNtkzVUQFWBgaHTWk4JX5W2hPkL47JeRebBxRbDE37T1gE7WtfCwRnurJixdLx9SvGj8Uif8kUqEw7SVcqwbPzcTRL7rXB3xUfN3Sk6QHcVexBWC79dHKNedFgaDZ84heXdUDR255m5kHyWuhEWF4kz9oKE", "MultisigV1SUX3fBezZrY7csuKj8s5C9jWThCo6PRERMEjFiahN3ABJdrQNmsPmRmVUuYh1a5mDCQjx8LBCbgM4KRiU9e2rFLY45mteKifQUR3SRY2bQsVyJRohU7jX8ob9XyWq1yp5sLi5yu8JuQTiV634cEn7VwtdagfRjibm9T7VjbUjN7NgQnr"]
 }
+
+### integrity
+GET http://localhost:6789/integrity

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webflux</artifactId>
-			<version>2.5.2</version>
+			<version>2.5.3</version>
 		</dependency>
 		<!-- hex conversion -->
 		<dependency>

--- a/src/main/java/org/hiahatf/mass/controllers/IntegrityController.java
+++ b/src/main/java/org/hiahatf/mass/controllers/IntegrityController.java
@@ -1,0 +1,73 @@
+package org.hiahatf.mass.controllers;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+
+import org.apache.commons.codec.binary.Hex;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.hiahatf.mass.models.Constants;
+import org.hiahatf.mass.models.Integrity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Hash application source code in the quote, swap and 
+ * integrity services. This controller will also return
+ * a hash of its own source code. Although this is not a
+ * perfect solution to determining if the swap server is
+ * a malicious it will deter attempting to fake the server
+ * hashes.
+ */
+@RequestMapping
+@RestController
+public class IntegrityController extends BaseController {
+    
+    private Logger logger = LoggerFactory.getLogger(IntegrityController.class);
+    
+    
+    /**
+	 * Hash source code
+	 * @return Mono<Integrity>
+	 */
+    @GetMapping(Constants.INTEGRITY_PATH)
+    @ResponseStatus(HttpStatus.OK)
+	public Mono<Integrity> validateIntegrity() throws IOException {
+		return Mono.just(Integrity.builder()
+            .integrity(hashIt(Constants.INTEGRITY_SRC))
+            .btcQuoteController(hashIt(Constants.BTC_QUOTE_CONTROLLER_SRC))
+            .btcQuoteService(hashIt(Constants.BTC_QUOTE_SERVICE_SRC))
+            .btcSwapController(hashIt(Constants.BTC_SWAP_CONTROLLER_SRC))
+            .btcSwapService(hashIt(Constants.BTC_SWAP_SERVICE_SRC))
+            .xmrQuoteController(hashIt(Constants.XMR_QUOTE_CONTROLLER_SRC))
+            .xmrQuoteService(hashIt(Constants.XMR_QUOTE_SERVICE_SRC))
+            .xmrSwapController(hashIt(Constants.XMR_SWAP_CONTROLLER_SRC))
+            .xmrSwapService(hashIt(Constants.XMR_SWAP_SERVICE_SRC))
+            .build());
+	}
+
+    private String hashIt(String stringPath) throws IOException {
+        Path path = FileSystems.getDefault().getPath(stringPath);
+        byte[] data = Files.readAllBytes(path);
+        Security.addProvider(new BouncyCastleProvider());
+        MessageDigest digest = null;
+        try {
+            digest = MessageDigest.getInstance(Constants.SHA_256);
+        } catch (NoSuchAlgorithmException e) {
+            logger.error(Constants.HASH_ERROR, e.getMessage());
+        }  
+        return Hex.encodeHexString(digest.digest(data));
+    }
+
+}

--- a/src/main/java/org/hiahatf/mass/models/Constants.java
+++ b/src/main/java/org/hiahatf/mass/models/Constants.java
@@ -8,6 +8,7 @@ public final class Constants {
 
     // controller values
     public static final String HEALTH_PATH = "/health";
+    public static final String INTEGRITY_PATH = "/integrity";
     public static final String XMR_QUOTE_PATH = "/quote/xmr";
     public static final String XMR_SWAP_FINAL_PATH = "/swap/xmr";
     public static final String XMR_SWAP_FUND_PATH = "/swap/fund/xmr";
@@ -18,6 +19,26 @@ public final class Constants {
     public static final String BTC_SWAP_FUND_PATH = "/swap/fund/btc";
     public static final String BTC_SWAP_INIT_PATH = "/swap/initialize/btc";
     public static final String BTC_CANCEL_PATH = "/swap/cancel/btc";
+
+    // Integrity values
+    public static final String XMR_QUOTE_CONTROLLER_SRC = 
+        "src/main/java/org/hiahatf/mass/controllers/monero/QuoteController.java";
+    public static final String XMR_SWAP_CONTROLLER_SRC = 
+        "src/main/java/org/hiahatf/mass/controllers/monero/SwapController.java";
+    public static final String XMR_QUOTE_SERVICE_SRC = 
+        "src/main/java/org/hiahatf/mass/services/monero/QuoteService.java";
+    public static final String XMR_SWAP_SERVICE_SRC = 
+        "src/main/java/org/hiahatf/mass/services/monero/SwapService.java";
+    public static final String BTC_QUOTE_CONTROLLER_SRC = 
+        "src/main/java/org/hiahatf/mass/controllers/bitcoin/QuoteController.java";
+    public static final String BTC_SWAP_CONTROLLER_SRC = 
+        "src/main/java/org/hiahatf/mass/controllers/bitcoin/SwapController.java";
+    public static final String BTC_QUOTE_SERVICE_SRC = 
+        "src/main/java/org/hiahatf/mass/services/bitcoin/QuoteService.java";
+    public static final String BTC_SWAP_SERVICE_SRC = 
+        "src/main/java/org/hiahatf/mass/services/bitcoin/SwapService.java";
+    public static final String INTEGRITY_SRC = 
+        "src/main/java/org/hiahatf/mass/controllers/IntegrityController.java";
     
     // model values
     public static final String MEMO = "mass";

--- a/src/main/java/org/hiahatf/mass/models/Integrity.java
+++ b/src/main/java/org/hiahatf/mass/models/Integrity.java
@@ -1,0 +1,25 @@
+package org.hiahatf.mass.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * POJO for the Integrity Response
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Integrity {
+    private String integrity;
+    private String btcQuoteController;
+    private String btcSwapController;
+    private String btcQuoteService;
+    private String btcSwapService;
+    private String xmrQuoteController;
+    private String xmrSwapController;
+    private String xmrQuoteService;
+    private String xmrSwapService;
+}

--- a/src/test/java/org/hiahatf/mass/controllers/IntegrityControllerTest.java
+++ b/src/test/java/org/hiahatf/mass/controllers/IntegrityControllerTest.java
@@ -1,0 +1,35 @@
+package org.hiahatf.mass.controllers;
+
+import java.io.IOException;
+
+import org.hiahatf.mass.models.Integrity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+@RunWith(JUnitPlatform.class)
+public class IntegrityControllerTest {
+    
+    private IntegrityController controller = new IntegrityController();
+
+    @Test
+    @DisplayName("Integrity Test")
+    public void integrityTest() throws IOException {
+        String expectedHash = "93c53eedd4fd32d832a4d4086f42ba8397d2d1690242183c128785a6e8969c7c";
+
+        Mono<Integrity> testIntegrity = controller.validateIntegrity();
+
+        StepVerifier.create(testIntegrity)
+        .expectNextMatches(r -> r.getIntegrity()
+          .equals(expectedHash))
+        .verifyComplete();
+    }
+    
+}


### PR DESCRIPTION
Add controller which hashes itself (SHA-256) along with the quote and swap services. It is not a perfect solution to deter malicious swap servers but makes it more difficult to spoof. Any modifications to the source code will cause mismatch hashes between the servers and break consensus.